### PR TITLE
Support for CoffeeScript

### DIFF
--- a/Commands/Validate CoffeeScript.tmCommand
+++ b/Commands/Validate CoffeeScript.tmCommand
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>beforeRunningCommand</key>
+	<string>saveActiveFile</string>
+	<key>command</key>
+	<string>#!/usr/bin/env ruby
+require ENV['TM_BUNDLE_SUPPORT'] + "/lib/validate_on_save"
+VOS::Validate.coffeescript</string>
+	<key>input</key>
+	<string>document</string>
+	<key>keyEquivalent</key>
+	<string>@s</string>
+	<key>name</key>
+	<string>Validate CoffeeScript</string>
+	<key>output</key>
+	<string>showAsTooltip</string>
+	<key>scope</key>
+	<string>source.coffee</string>
+	<key>uuid</key>
+	<string>84CF05E4-3567-4AF2-BEB9-05F533B2F3E3</string>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This bundle lets you skips several of those steps.
 Supported Languages
 -------------------
 
+  * CoffeeScript
   * CSS
   * Erlang (possibly buggy, compiles *.beam file using erlc)
   * Haml
@@ -62,8 +63,9 @@ You can customize how and when VOS (Validate On Save) notifies you. This is done
   
 ### Binary Path Options:
 
-These options are used to specify the full path to the executable binaries for the different commands VOS relies upon. With the exception of `TM_GROWLNOTIFY`, `TM_RUBY`, and `TM_ERB`, all of these must be specified for they're corresponding validator to work.
+These options are used to specify the full path to the executable binaries for the different commands VOS relies upon. With the exception of `TM_GROWLNOTIFY`, `TM_RUBY`, `TM_COFFEESCRIPT` and `TM_ERB`, all of these must be specified for their corresponding validator to work.
 
+  * `TM_COFFEESCRIPT`
   * `TM_COMPASS`
   * `TM_ERB`
   * `TM_ERLC`

--- a/Support/lib/validate_on_save.rb
+++ b/Support/lib/validate_on_save.rb
@@ -27,6 +27,7 @@ class VOS
   def self.validate
     scope = ENV["TM_SCOPE"]
     scopes = {
+      :coffeescript => { :is => /source\.coffee/ },
       :css => { :is => /source\.css/ },
       :erlang => { :is => /source\.erlang/ },
       :haml => { :is => /text\.haml/ },

--- a/Support/lib/validate_on_save/validators.rb
+++ b/Support/lib/validate_on_save/validators.rb
@@ -1,3 +1,4 @@
+require "validate_on_save/validators/coffeescript"
 require "validate_on_save/validators/css"
 require "validate_on_save/validators/erlang"
 require "validate_on_save/validators/erb"

--- a/Support/lib/validate_on_save/validators/coffeescript.rb
+++ b/Support/lib/validate_on_save/validators/coffeescript.rb
@@ -1,0 +1,15 @@
+class VOS
+  class Validate
+    def self.coffeescript
+      binary = ENV['TM_COFFEESCRIPT'] ||= "coffee"
+      filepath = ENV['TM_FILEPATH']
+      VOS.output({
+        :info => "Running syntax check with CoffeeScript lint\n",
+        :result => `"#{binary}" --lint #{filepath} 2>&1`.sub(/^Error.*\.coffee, /, ''),
+        :match_ok => /0 error\(s\)\, /i, # ignore warnings
+        :match_line => /line (\d+)/i,
+        :lang => "CoffeeScript"
+      })
+    end
+  end
+end

--- a/info.plist
+++ b/info.plist
@@ -28,6 +28,7 @@
 	<key>ordering</key>
 	<array>
 		<string>003C16AB-C2FD-4AB8-99E2-A7B22C126626</string>
+		<string>84CF05E4-3567-4AF2-BEB9-05F533B2F3E3</string>
 		<string>33995B55-507A-4F3B-839E-70D0A298DC9E</string>
 		<string>1F48EAC4-2186-4517-8180-DE8B02D40D2C</string>
 		<string>079F7B17-51B5-4C09-8577-77D6A0D827F2</string>


### PR DESCRIPTION
Uses CoffeeScript's lint option to syntax check. Ignores warnings since
they're pretty pedantic, e.g. "parseInt missing radix parameter"
