### PR TITLE
Bug fix for CoffeeScript

### DIFF
--- a/Support/lib/validate_on_save/validators/coffeescript.rb
+++ b/Support/lib/validate_on_save/validators/coffeescript.rb
@@ -5,7 +5,7 @@ class VOS
       filepath = ENV['TM_FILEPATH']
       VOS.output({
         :info => "Running syntax check with CoffeeScript lint\n",
-        :result => `"#{binary}" --lint #{filepath} 2>&1`.sub(/^Error.*\.coffee, /, ''),
+        :result => `"#{binary}" --lint "#{filepath}" 2>&1`.sub(/^Error.*\.coffee, /, ''),
         :match_ok => /0 error\(s\)\, /i, # ignore warnings
         :match_line => /line (\d+)/i,
         :lang => "CoffeeScript"


### PR DESCRIPTION
Currently, Validate On Save can't read CoffeeScript files that are in a directory structure that contains spaces. This is the easy fix.
