### PR TITLE
add erlang's -pa option for recognize ebin directory while checking syntax.

### DIFF
--- a/Support/lib/validate_on_save/validators/erlang.rb
+++ b/Support/lib/validate_on_save/validators/erlang.rb
@@ -4,9 +4,11 @@ class VOS
       erlc_bin = ENV['TM_ERLC'] ||= "erlc"
       tmp = VOS.opt("VOS_ERL_OUTPUT_TO_TMP")
       output = (tmp) ? "-o /tmp" : ""
+      option = "-pa #{ENV['TM_PROJECT_DIRECTORY']}/ebin"
+      option += " -pa #{ENV['TM_PROJECT_DIRECTORY']}/apps/*/ebin"
       VOS.output({
         :info => "",
-        :result => `"#{erlc_bin}" #{output} "#{ENV['TM_FILEPATH']}"`,
+        :result => `"#{erlc_bin}" #{output} #{option} "#{ENV['TM_FILEPATH']}"`,
         :match_ok => /^$/i,
         :match_line => /.*?#{Regexp.escape(ENV['TM_FILENAME'])}\:(\d+)\:.*/i,
         :lang => "Erlang"


### PR DESCRIPTION
Erlang have to recognize the other beam files in order to do valid syntax check on erlang project

I added two "-pa" option while execute erl for general OTP project.
1. #{ENV['TM_PROJECT_DIRECTORY']}/ebin
2. #{ENV['TM_PROJECT_DIRECTORY']}/apps/*/ebin

Please check this commit.
