### PR TITLE
coffee binary no longer supports --lint option

### DIFF
--- a/Support/lib/validate_on_save/validators/coffeescript.rb
+++ b/Support/lib/validate_on_save/validators/coffeescript.rb
@@ -1,11 +1,11 @@
 class VOS
   class Validate
     def self.coffeescript
-      binary = ENV['TM_COFFEESCRIPT'] ||= "coffee"
+      binary = ENV['TM_COFFEESLINT'] ||= "coffeelint"
       filepath = ENV['TM_FILEPATH']
       VOS.output({
         :info => "Running syntax check with CoffeeScript lint\n",
-        :result => `"#{binary}" --lint "#{filepath}" 2>&1`.sub(/^Error.*\.coffee, /, ''),
+        :result => `"#{binary}" "#{filepath}" 2>&1`.sub(/^Error.*\.coffee, /, ''),
         :match_ok => /0 error\(s\)\, /i, # ignore warnings
         :match_line => /line (\d+)/i,
         :lang => "CoffeeScript"


### PR DESCRIPTION
Use coffeelint npm module instead.

Insteall using

```npm install -g coffeelint

Then this will work beautifully
