### PR TITLE
Show ruby warnings even if syntax OK

### DIFF
--- a/Support/lib/validate_on_save/validators/ruby.rb
+++ b/Support/lib/validate_on_save/validators/ruby.rb
@@ -5,7 +5,7 @@ class VOS
       VOS.output({
         :info => `"#{ruby_bin}" -e'puts "Running syntax check with ruby-" + RUBY_VERSION.to_s'`,
         :result => `"#{ruby_bin}" -wc 2>&1`.gsub(/\-\:([0-9]+)\: /i, 'Line \1: '),
-        :match_ok => /Syntax OK/i,
+        :match_ok => /(?<!\n)Syntax OK/im,
         :match_line => /line (\d+)/i,
         :lang => "Ruby"
       })


### PR DESCRIPTION
On Ruby 2.1.2 the "Syntax OK" message is displayed even if there are warnings (such as unused variables) in the file - so potentially useful warnings would be hidden. This change modifies the `match_ok` regex to use multiline matching and a negative lookbehind assertion to verify that there is not a newline before the "Syntax OK" message.
