### PR TITLE
Use VOS-specific Ruby variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,17 @@ These options are used to specify the full path to the executable binaries for t
   * `TM_HAML`
   * `TM_PERL`
   * `TM_PYFLAKES`
-  * `TM_RUBY`
+  * `TM_RUBY`/`TM_VOS_RUBY`
   * `TM_SASS`
 
 ### Regarding `TM_SASS` and `TM_COMPASS`:
 
 If `TM_COMPASS` is set to "false", validation is done using the standard Sass binary.
+
+### Regarding `TM_RUBY` and `TM_VOS_RUBY`:
+
+`TM_VOS_RUBY` takes priority over `TM_RUBY` and is useful in the cases that you
+want TextMate to use a different Ruby or Ruby wrapper for validation vs. testing as `TM_VOS_RUBY` is always run with `-w`.
 
 ### Regarding `env: ... No such file or directory`
 

--- a/Support/lib/validate_on_save/validators/erb.rb
+++ b/Support/lib/validate_on_save/validators/erb.rb
@@ -1,8 +1,8 @@
 class VOS
   class Validate
     def self.erb
-      ruby_bin = ENV['TM_RUBY'] ||= "ruby"
-      erb_bin = ENV["TM_ERB"] ||= "erb"
+      ruby_bin = ENV['TM_VOS_RUBY'] || ENV['TM_RUBY'] || "ruby"
+      erb_bin = ENV["TM_ERB"] || "erb"
       VOS.output({
         :info => `"#{ruby_bin}" -e'puts "Running syntax check with erb and ruby-" + RUBY_VERSION.to_s'`,
         :result => `"#{erb_bin}" -T - -x | "#{ruby_bin}" -c 2>&1`.gsub(/\-\:([0-9]+)\: /i, 'Line \1: '),

--- a/Support/lib/validate_on_save/validators/ruby.rb
+++ b/Support/lib/validate_on_save/validators/ruby.rb
@@ -1,7 +1,7 @@
 class VOS
   class Validate
     def self.ruby
-      ruby_bin = ENV['TM_RUBY'] ||= "ruby"
+      ruby_bin = ENV['TM_VOS_RUBY'] || ENV['TM_RUBY'] || "ruby"
       VOS.output({
         :info => `"#{ruby_bin}" -e'puts "Running syntax check with ruby-" + RUBY_VERSION.to_s'`,
         :result => `"#{ruby_bin}" -wc 2>&1`.gsub(/\-\:([0-9]+)\: /i, 'Line \1: '),


### PR DESCRIPTION
Sometimes the Ruby (or wrapper) you use for TextMate in general may do weird things or print unhelpful/spammy output when run with `-w` for use with VOS. In this case it's nice to have a separate variable that you can use to take priority over `TM_RUBY`.