### PR TITLE
Add Shellcheck and RuboCop validators for Bash/Ruby

### DIFF
--- a/Commands/Validate Bash.tmCommand
+++ b/Commands/Validate Bash.tmCommand
@@ -7,7 +7,7 @@
 	<key>command</key>
 	<string>#!/usr/bin/env ruby
 require ENV['TM_BUNDLE_SUPPORT'] + "/lib/validate_on_save"
-VOS::Validate.bash</string>
+VOS::Validate.bash_select</string>
 	<key>input</key>
 	<string>document</string>
 	<key>keyEquivalent</key>

--- a/Commands/Validate Ruby.tmCommand
+++ b/Commands/Validate Ruby.tmCommand
@@ -7,7 +7,7 @@
 	<key>command</key>
 	<string>#!/usr/bin/env ruby
 require ENV['TM_BUNDLE_SUPPORT'] + "/lib/validate_on_save"
-VOS::Validate.ruby</string>
+VOS::Validate.ruby_select</string>
 	<key>input</key>
 	<string>document</string>
 	<key>keyEquivalent</key>

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ You can customize how and when VOS (Validate On Save) notifies you. This is done
   * `VOS_TM_NOTIFY`: Display the validation result in a TextMate tooltip. If you use Growl, you might want to disable this. (defaults to "true")
   * `VOS_GROWL`: Use Growl to display the validation result. (defaults to "false")
   * `VOS_JUMP_TO_ERROR`: When a error is found, automatically move the cursor to the line causing the problem. (defaults to "false")
+  * `VOS_TRIM_LINES`: Remove trailing whitespaces from non-empty lines  (defaults to "true")
+  * `VOS_TRIM_DOCUMENT`:  Remove trailing whitespaces and new lines from end of document (defaults to "false")
   * `VOS_ERL_OUTPUT_TO_TMP`: When validating Erlang, the `.erl` file you are working on needs to be compiled to a `.beam` file to look for any syntax errors. By default when VOS compiles your file, it outputs the resulting compiled beam file to `/tmp` after which it removes it. Set this to false to have the beam file be outout to the same directory as the `.erl` file you are working on. (defaults to "false")
   * `VOS_CSS_PROFILE`: When to validate css against a specific profile. See [CSS Validator sommand settings][w3ccss] for a list of valid profiles. (defaults to 2.1)
   * `VOS_BASH_SHELLCHECK`: use Shellcheck instead of Bash to check shell scripts

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Supported Languages
   * Perl
   * PHP
   * Python (using PyFlakes)
-  * Ruby
+  * Ruby (optionally using Rubocop)
   * Sass/Compass (still a bit buggy)
 
 
@@ -63,6 +63,7 @@ You can customize how and when VOS (Validate On Save) notifies you. This is done
   * `VOS_ERL_OUTPUT_TO_TMP`: When validating Erlang, the `.erl` file you are working on needs to be compiled to a `.beam` file to look for any syntax errors. By default when VOS compiles your file, it outputs the resulting compiled beam file to `/tmp` after which it removes it. Set this to false to have the beam file be outout to the same directory as the `.erl` file you are working on. (defaults to "false")
   * `VOS_CSS_PROFILE`: When to validate css against a specific profile. See [CSS Validator sommand settings][w3ccss] for a list of valid profiles. (defaults to 2.1)
   * `VOS_BASH_SHELLCHECK`: use Shellcheck instead of Bash to check shell scripts
+  * `VOS_RUBY_RUBOCOP`: use RuboCop instead of Ruby to check Ruby scripts
   
 ### Binary Path Options:
 
@@ -77,6 +78,7 @@ These options are used to specify the full path to the executable binaries for t
   * `TM_HAML`
   * `TM_PERL`
   * `TM_PYFLAKES`
+  * `TM_RUBOCOP`
   * `TM_RUBY`/`TM_VOS_RUBY`
   * `TM_SASS`
   * `TM_SHELLCHECK`

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This bundle lets you skips several of those steps.
 Supported Languages
 -------------------
 
-  * Bash
+  * Bash (optionally using Shellcheck)
   * CoffeeScript
   * CSS
   * Erlang (possibly buggy, compiles *.beam file using erlc)
@@ -62,6 +62,7 @@ You can customize how and when VOS (Validate On Save) notifies you. This is done
   * `VOS_JUMP_TO_ERROR`: When a error is found, automatically move the cursor to the line causing the problem. (defaults to "false")
   * `VOS_ERL_OUTPUT_TO_TMP`: When validating Erlang, the `.erl` file you are working on needs to be compiled to a `.beam` file to look for any syntax errors. By default when VOS compiles your file, it outputs the resulting compiled beam file to `/tmp` after which it removes it. Set this to false to have the beam file be outout to the same directory as the `.erl` file you are working on. (defaults to "false")
   * `VOS_CSS_PROFILE`: When to validate css against a specific profile. See [CSS Validator sommand settings][w3ccss] for a list of valid profiles. (defaults to 2.1)
+  * `VOS_BASH_SHELLCHECK`: use Shellcheck instead of Bash to check shell scripts
   
 ### Binary Path Options:
 
@@ -78,6 +79,7 @@ These options are used to specify the full path to the executable binaries for t
   * `TM_PYFLAKES`
   * `TM_RUBY`/`TM_VOS_RUBY`
   * `TM_SASS`
+  * `TM_SHELLCHECK`
 
 ### Regarding `TM_SASS` and `TM_COMPASS`:
 

--- a/Support/lib/validate_on_save/validators/bash.rb
+++ b/Support/lib/validate_on_save/validators/bash.rb
@@ -1,11 +1,31 @@
 class VOS
   class Validate
+    def self.bash_select
+      if ENV["VOS_BASH_SHELLCHECK"]
+        shellcheck
+      else
+        bash
+      end
+    end
+
     def self.bash
       bash_bin = ENV["TM_BASH"] ||= "bash"
       VOS.output({
         :info => `echo Running syntax check with bash-$("#{bash_bin}" --version | head -n1 | awk {'print $4'})`,
         :result => `"#{bash_bin}" -n 2>&1`,
         :match_ok => /^$/i,
+        :match_line => /line (\d+)/i,
+        :lang => "Bash"
+      })
+    end
+
+    def self.shellcheck
+      shellcheck_bin = ENV["TM_SHELLCHECK"] ||= "shellcheck"
+      filepath = ENV["TM_FILEPATH"]
+      VOS.output({
+        :info => `echo Running syntax check with shellcheck-$("#{shellcheck_bin}" --version | head -n2 | tail -n1 | awk {'print $2'})`,
+        :result => `"#{shellcheck_bin}" --shell=bash "#{filepath}" && echo VOSOK!`,
+        :match_ok => /^VOSOK!$/,
         :match_line => /line (\d+)/i,
         :lang => "Bash"
       })

--- a/Support/lib/validate_on_save/validators/ruby.rb
+++ b/Support/lib/validate_on_save/validators/ruby.rb
@@ -1,5 +1,13 @@
 class VOS
   class Validate
+    def self.ruby_select
+      if ENV["VOS_RUBY_RUBOCOP"]
+        rubocop
+      else
+        ruby
+      end
+    end
+
     def self.ruby
       ruby_bin = ENV['TM_VOS_RUBY'] || ENV['TM_RUBY'] || "ruby"
       VOS.output({
@@ -7,6 +15,18 @@ class VOS
         :result => `"#{ruby_bin}" -wc 2>&1`.gsub(/\-\:([0-9]+)\: /i, 'Line \1: '),
         :match_ok => /(?<!\n)Syntax OK/im,
         :match_line => /line (\d+)/i,
+        :lang => "Ruby"
+      })
+    end
+
+    def self.rubocop
+      rubocop_bin = ENV['TM_RUBOCOP'] || "rubocop"
+      filepath = ENV["TM_FILEPATH"]
+      VOS.output({
+        :info => `echo Running syntax check with rubocop-$("#{rubocop_bin}" --version)`,
+        :result => `"#{rubocop_bin}" --format clang "#{filepath}"`,
+        :match_ok => /(no|0) offenses/,
+        :match_line => /\S+:(\d+):\d+: /,
         :lang => "Ruby"
       })
     end


### PR DESCRIPTION
Add optional validators for Shellcheck and RuboCop to use instead of `bash` and `ruby`. Also, while I was there, add some missing options to the README.

If this approach isn't what you'd like: that's cool; I'm not married to it and I'm happy to tweak how it's done.

Thanks again for the great project!

CC @sxtxixtxcxh @claylo for thoughts.

Closes #27
