### PR TITLE
Add support for HTML output.

### DIFF
--- a/Commands/Validate Bash.tmCommand
+++ b/Commands/Validate Bash.tmCommand
@@ -10,12 +10,18 @@ require ENV['TM_BUNDLE_SUPPORT'] + "/lib/validate_on_save"
 VOS::Validate.bash_select</string>
 	<key>input</key>
 	<string>document</string>
+	<key>inputFormat</key>
+	<string>text</string>
 	<key>keyEquivalent</key>
 	<string>@s</string>
 	<key>name</key>
 	<string>Validate Bash</string>
-	<key>output</key>
-	<string>showAsTooltip</string>
+	<key>outputCaret</key>
+	<string>afterOutput</string>
+	<key>outputFormat</key>
+	<string>html</string>
+	<key>outputLocation</key>
+	<string>newWindow</string>
 	<key>scope</key>
 	<string>source.shell</string>
 	<key>uuid</key>

--- a/Commands/Validate JSON.tmCommand
+++ b/Commands/Validate JSON.tmCommand
@@ -12,15 +12,23 @@ VOS::Validate.json</string>
 	<string>scope</string>
 	<key>input</key>
 	<string>document</string>
+	<key>inputFormat</key>
+	<string>text</string>
 	<key>keyEquivalent</key>
 	<string>@s</string>
 	<key>name</key>
 	<string>Validate JSON</string>
-	<key>output</key>
-	<string>showAsTooltip</string>
+	<key>outputCaret</key>
+	<string>afterOutput</string>
+	<key>outputFormat</key>
+	<string>html</string>
+	<key>outputLocation</key>
+	<string>newWindow</string>
 	<key>scope</key>
 	<string>source.json</string>
 	<key>uuid</key>
 	<string>5A6C8946-B6E1-42B0-B52E-E20602FBC3F0</string>
+	<key>version</key>
+	<integer>2</integer>
 </dict>
 </plist>

--- a/Commands/Validate Ruby.tmCommand
+++ b/Commands/Validate Ruby.tmCommand
@@ -10,12 +10,18 @@ require ENV['TM_BUNDLE_SUPPORT'] + "/lib/validate_on_save"
 VOS::Validate.ruby_select</string>
 	<key>input</key>
 	<string>document</string>
+	<key>inputFormat</key>
+	<string>text</string>
 	<key>keyEquivalent</key>
 	<string>@s</string>
 	<key>name</key>
 	<string>Validate Ruby</string>
-	<key>output</key>
-	<string>showAsTooltip</string>
+	<key>outputCaret</key>
+	<string>afterOutput</string>
+	<key>outputFormat</key>
+	<string>html</string>
+	<key>outputLocation</key>
+	<string>newWindow</string>
 	<key>scope</key>
 	<string>source.ruby - source.ruby.embedded.haml - text.html.ruby</string>
 	<key>uuid</key>

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Follow these instructions if you have Git installed:
     
 Installing via Git will allow you to keep up to date with the `Bundles` > `Validate On Save` > `Update Bundle` menu command.
 
-If you don't have Git and downloaded this from Github (really? you don't have Git?), after you've unzipped or untarred, you'll have to rename the folder from `sxtxixtxcxh-validate-on-save.tmbundle-#{HASH}` to `Validate On Save.tmbundle`. Double click and TextMate should install it for you.
+If you don't have Git and downloaded this from GitHub (really? you don't have Git?), after you've unzipped or untarred, you'll have to rename the folder from `sxtxixtxcxh-validate-on-save.tmbundle-#{HASH}` to `Validate On Save.tmbundle`. Double click and TextMate should install it for you.
 
 
 Configuration
@@ -58,6 +58,7 @@ You can customize how and when VOS (Validate On Save) notifies you. This is done
   * `VOS_VALIDATOR_INFO`: Outputs information about the validator. (defaults to "false")
   * `VOS_ONLY_ON_ERROR`: Only displays notifications on syntax error. Useful if you don't want to be told repeatedly that everything is OK. (defaults to "false")
   * `VOS_TM_NOTIFY`: Display the validation result in a TextMate tooltip. If you use Growl, you might want to disable this. (defaults to "true")
+  * `VOS_HTML`: Display the validation result in the TextMate HTML output (defaults to "false")
   * `VOS_GROWL`: Use Growl to display the validation result. (defaults to "false")
   * `VOS_JUMP_TO_ERROR`: When a error is found, automatically move the cursor to the line causing the problem. (defaults to "false")
   * `VOS_TRIM_LINES`: Remove trailing whitespaces from non-empty lines  (defaults to "true")

--- a/Support/lib/validate_on_save.rb
+++ b/Support/lib/validate_on_save.rb
@@ -75,6 +75,21 @@ class VOS
   # Util methods
   #
   
+  def self.htmlify_results(result, filepath)
+    return result unless VOS.opt("VOS_HTML")
+    filename = File.basename(filepath)
+    result.gsub!(filepath, "")
+    result = <<-EOS
+<h3><a href='txmt://open/?url=file://#{filepath}'>#{filename}:</a></h3>
+#{result}
+EOS
+    result.gsub!(/:(\d+):(\d+): /,
+      "<li><a href='txmt://open/?url=file://#{filepath}&line=\\1&column=\\2'>L\\1</a> ")
+    result.gsub!(/line (\d+), col (\d+), found: /,
+      "<li><a href='txmt://open/?url=file://#{filepath}&line=\\1&column=\\2'>L\\1</a>: ")
+    result
+  end
+
   def self.opt(key)
     if ENV.has_key?(key)
       return (ENV[key] == "true") ? true : false

--- a/Support/lib/validate_on_save/defaults.rb
+++ b/Support/lib/validate_on_save/defaults.rb
@@ -17,6 +17,9 @@ VOS_TM_NOTIFY = true
 # Use Growl notification
 VOS_GROWL = false
 
+# Use HTML output
+VOS_HTML = false
+
 # Jump to line with error
 VOS_JUMP_TO_ERROR = false
 

--- a/Support/lib/validate_on_save/validators/bash.rb
+++ b/Support/lib/validate_on_save/validators/bash.rb
@@ -22,10 +22,17 @@ class VOS
     def self.shellcheck
       shellcheck_bin = ENV["TM_SHELLCHECK"] ||= "shellcheck"
       filepath = ENV["TM_FILEPATH"]
+
+      info = `echo Running syntax check with shellcheck-$("#{shellcheck_bin}" --version | head -n2 | tail -n1 | awk {'print $2'})`
+
+      format = ENV["VOS_HTML"] ? "gcc" : "tty"
+      result = `"#{shellcheck_bin}" --shell=bash --format=#{format} "#{filepath}" && echo VOSOK`
+      result = VOS.htmlify_results(result, filepath)
+
       VOS.output({
-        :info => `echo Running syntax check with shellcheck-$("#{shellcheck_bin}" --version | head -n2 | tail -n1 | awk {'print $2'})`,
-        :result => `"#{shellcheck_bin}" --shell=bash "#{filepath}" && echo VOSOK!`,
-        :match_ok => /^VOSOK!$/,
+        :info => info,
+        :result => result.gsub(/^VOSOK$/, ""),
+        :match_ok => /^VOSOK$/,
         :match_line => /line (\d+)/i,
         :lang => "Bash"
       })

--- a/Support/lib/validate_on_save/validators/json.rb
+++ b/Support/lib/validate_on_save/validators/json.rb
@@ -4,10 +4,16 @@ class VOS
       filename = ENV['TM_FILENAME']
       filepath = ENV['TM_FILEPATH']
       binary   = ENV['TM_JSONLINT'] || 'jsonlint'
+
+      info = `echo Running syntax check with jsonlint-$("#{binary}" --version)`
+
+      result = `"#{binary}" "#{filepath}" --compact --quiet 2>&1`.gsub("#{filepath}: ", '')
+      result = VOS.htmlify_results(result, filepath)
+
       VOS.output({
-        :info => "Running syntax check with jsonlint\n",
-        :result => `"#{binary}" #{filepath} --compact --quiet 2>&1`.gsub("#{filepath}: ", ''),
-        :match_ok => /^$/i,
+        :info => info,
+        :result => result.chomp,
+        :match_ok => /^$/,
         :match_line => /line (\d+)/i,
         :lang => "JSON"
       })

--- a/Support/lib/validate_on_save/validators/ruby.rb
+++ b/Support/lib/validate_on_save/validators/ruby.rb
@@ -22,9 +22,16 @@ class VOS
     def self.rubocop
       rubocop_bin = ENV['TM_RUBOCOP'] || "rubocop"
       filepath = ENV["TM_FILEPATH"]
+
+      info = `echo Running syntax check with rubocop-$("#{rubocop_bin}" --version)`
+
+      format = VOS.opt("VOS_HTML") ? "emacs" : "clang"
+      result = `"#{rubocop_bin}" --format #{format} "#{filepath}"`
+      result = VOS.htmlify_results(result, filepath)
+
       VOS.output({
-        :info => `echo Running syntax check with rubocop-$("#{rubocop_bin}" --version)`,
-        :result => `"#{rubocop_bin}" --format clang "#{filepath}"`,
+        :info => info,
+        :result => result,
         :match_ok => /(no|0) offenses/,
         :match_line => /\S+:(\d+):\d+: /,
         :lang => "Ruby"


### PR DESCRIPTION
Add support for commands to produce HTML output. Currently this just has been implemented for RuboCop, JSONLint and Shellcheck.

Not sure how to make this conditional on the Validate commands or if that’s even possible?

Let me know what you think about this and whether it makes more sense to fork the project instead. Personally I find the HTML output window to be a far superior method of using this bundle.